### PR TITLE
chore(dep): Replace centreon frontend dependency url dev-22.04.x

### DIFF
--- a/centreon/package-lock.json
+++ b/centreon/package-lock.json
@@ -17,7 +17,7 @@
         "@mui/styles": "^5.3.0",
         "@visx/visx": "2.9.0",
         "axios": "^0.25.0",
-        "centreon-frontend": "git+https://centreon@github.com/centreon/centreon-frontend.git#dev-22.04.x",
+        "centreon-frontend": "https://gitpkg.now.sh/centreon/centreon-gha/centreon-frontend?dev-22.04.x",
         "classnames": "^2.3.1",
         "clsx": "^1.1.1",
         "connected-react-router": "^6.9.2",
@@ -6753,7 +6753,8 @@
     },
     "node_modules/centreon-frontend": {
       "version": "22.4.0",
-      "resolved": "git+https://centreon@github.com/centreon/centreon-frontend.git#1e72f0bcb8436383af4791aba95c20a47a067295",
+      "resolved": "https://gitpkg.now.sh/centreon/centreon-gha/centreon-frontend?dev-22.04.x",
+      "integrity": "sha512-KwqCA7Z9WoS3bplTcj7Go131AEHoJJX4vehh+bwnmY3X1k1C5bE/EjluFDnoOp1e6NbbrRb1z2aGq+Khy6Cpmw==",
       "license": "GPL-2.0",
       "dependencies": {
         "@dnd-kit/core": "^5.0.1",
@@ -22513,8 +22514,8 @@
       "dev": true
     },
     "centreon-frontend": {
-      "version": "git+https://centreon@github.com/centreon/centreon-frontend.git#1e72f0bcb8436383af4791aba95c20a47a067295",
-      "from": "centreon-frontend@git+https://centreon@github.com/centreon/centreon-frontend.git#dev-22.04.x",
+      "version": "https://gitpkg.now.sh/centreon/centreon-gha/centreon-frontend?dev-22.04.x",
+      "integrity": "sha512-KwqCA7Z9WoS3bplTcj7Go131AEHoJJX4vehh+bwnmY3X1k1C5bE/EjluFDnoOp1e6NbbrRb1z2aGq+Khy6Cpmw==",
       "requires": {
         "@dnd-kit/core": "^5.0.1",
         "@dnd-kit/modifiers": "^5.0.0",

--- a/centreon/package.json
+++ b/centreon/package.json
@@ -97,7 +97,7 @@
     "@mui/styles": "^5.3.0",
     "@visx/visx": "2.9.0",
     "axios": "^0.25.0",
-    "centreon-frontend": "git+https://centreon@github.com/centreon/centreon-frontend.git#dev-22.04.x",
+    "centreon-frontend": "https://gitpkg.now.sh/centreon/centreon-gha/centreon-frontend?dev-22.04.x",
     "classnames": "^2.3.1",
     "clsx": "^1.1.1",
     "connected-react-router": "^6.9.2",


### PR DESCRIPTION
## Description

This replaces the url for the npm dependency centreon-frontend

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.04.x
- [ ] 21.10.x
- [ ] 22.04.x
- [x] 22.10.x (master)

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
