### PR TITLE
Use old centreon-frontend repo on 22.04.x

### DIFF
--- a/centreon/package-lock.json
+++ b/centreon/package-lock.json
@@ -17,7 +17,7 @@
         "@mui/styles": "^5.3.0",
         "@visx/visx": "2.9.0",
         "axios": "^0.25.0",
-        "centreon-frontend": "https://gitpkg.now.sh/centreon/centreon-gha/centreon-frontend?dev-22.04.x",
+        "centreon-frontend": "git+https://centreon@github.com/centreon/centreon-frontend.git#dev-22.04.x",
         "classnames": "^2.3.1",
         "clsx": "^1.1.1",
         "connected-react-router": "^6.9.2",
@@ -6753,8 +6753,7 @@
     },
     "node_modules/centreon-frontend": {
       "version": "22.4.0",
-      "resolved": "https://gitpkg.now.sh/centreon/centreon-gha/centreon-frontend?dev-22.04.x",
-      "integrity": "sha512-KwqCA7Z9WoS3bplTcj7Go131AEHoJJX4vehh+bwnmY3X1k1C5bE/EjluFDnoOp1e6NbbrRb1z2aGq+Khy6Cpmw==",
+      "resolved": "git+https://centreon@github.com/centreon/centreon-frontend.git#1e72f0bcb8436383af4791aba95c20a47a067295",
       "license": "GPL-2.0",
       "dependencies": {
         "@dnd-kit/core": "^5.0.1",
@@ -22514,8 +22513,8 @@
       "dev": true
     },
     "centreon-frontend": {
-      "version": "https://gitpkg.now.sh/centreon/centreon-gha/centreon-frontend?dev-22.04.x",
-      "integrity": "sha512-KwqCA7Z9WoS3bplTcj7Go131AEHoJJX4vehh+bwnmY3X1k1C5bE/EjluFDnoOp1e6NbbrRb1z2aGq+Khy6Cpmw==",
+      "version": "git+https://centreon@github.com/centreon/centreon-frontend.git#1e72f0bcb8436383af4791aba95c20a47a067295",
+      "from": "centreon-frontend@git+https://centreon@github.com/centreon/centreon-frontend.git#dev-22.04.x",
       "requires": {
         "@dnd-kit/core": "^5.0.1",
         "@dnd-kit/modifiers": "^5.0.0",

--- a/centreon/package.json
+++ b/centreon/package.json
@@ -97,7 +97,7 @@
     "@mui/styles": "^5.3.0",
     "@visx/visx": "2.9.0",
     "axios": "^0.25.0",
-    "centreon-frontend": "https://gitpkg.now.sh/centreon/centreon-gha/centreon-frontend?dev-22.04.x",
+    "centreon-frontend": "git+https://centreon@github.com/centreon/centreon-frontend.git#dev-22.04.x",
     "classnames": "^2.3.1",
     "clsx": "^1.1.1",
     "connected-react-router": "^6.9.2",


### PR DESCRIPTION
This uses the old centreob-frontend repo as centreon's npm dependency