### PR TITLE
add yum clean all to web centos 7 dockerfile

### DIFF
--- a/ci/docker/Dockerfile.centreon-web-centos7
+++ b/ci/docker/Dockerfile.centreon-web-centos7
@@ -2,6 +2,8 @@ FROM registry-docker.centreon.com/docker-global/centos:7 AS web_fresh
 
 RUN <<EOF
 
+yum clean all --enablerepo=*
+
 yum install -y centos-release-scl
 
 curl -o remi-release-7.rpm https://rpms.remirepo.net/enterprise/remi-release-7.rpm


### PR DESCRIPTION
## Description

add force cache clean of yum cache to make sure all repodata it attempts to fetch are the latest ones (to avoid any 404 when trying to fetch outdated metadata)
This should fix the semi random issue below 
`#10 27.81 https://yum.centreon.com/standard/22.10/el7/stable/noarch/repodata/ab50520077ee89a61030b2f59c9236e9b21f75aead358d3ffc7e986fc37006c5-primary.sqlite.bz2: [Errno 14] HTTPS Error 404 - Not Found
`

**Fixes** # (issue)

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.04.x
- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x (master)

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
