### PR TITLE
Change module type to 'module' instead of 'umd' in webpack configuration

### DIFF
--- a/centreon/packages/js-config/webpack/base/index.js
+++ b/centreon/packages/js-config/webpack/base/index.js
@@ -11,9 +11,6 @@ const getBaseConfiguration = ({
   jscTransformConfiguration,
 }) => ({
   cache: false,
-  experiments: {
-    outputModule: true,
-  },
   module: {
     rules: [
       {
@@ -64,7 +61,7 @@ const getBaseConfiguration = ({
   output: {
     chunkFilename: '[name].[chunkhash:8].chunk.js',
     filename: '[name].[chunkhash:8].js',
-    libraryTarget: 'module',
+    libraryTarget: 'umd',
     umdNamedDefine: true,
   },
   plugins: [

--- a/centreon/packages/js-config/webpack/base/index.js
+++ b/centreon/packages/js-config/webpack/base/index.js
@@ -11,6 +11,9 @@ const getBaseConfiguration = ({
   jscTransformConfiguration,
 }) => ({
   cache: false,
+  experiments: {
+    outputModule: true,
+  },
   module: {
     rules: [
       {
@@ -61,7 +64,7 @@ const getBaseConfiguration = ({
   output: {
     chunkFilename: '[name].[chunkhash:8].chunk.js',
     filename: '[name].[chunkhash:8].js',
-    libraryTarget: 'umd',
+    libraryTarget: 'module',
     umdNamedDefine: true,
   },
   plugins: [

--- a/centreon/packages/js-config/webpack/base/index.js
+++ b/centreon/packages/js-config/webpack/base/index.js
@@ -5,13 +5,15 @@ const { ModuleFederationPlugin } = require('webpack').container;
 
 const excludeNodeModulesExceptCentreonUi = /node_modules(\\|\/)(?!(@centreon))/;
 
-//comment 
 const getBaseConfiguration = ({
   moduleName,
   moduleFederationConfig,
   jscTransformConfiguration,
 }) => ({
   cache: false,
+  experiments: {
+    outputModule: true,
+  },
   module: {
     rules: [
       {
@@ -62,8 +64,7 @@ const getBaseConfiguration = ({
   output: {
     chunkFilename: '[name].[chunkhash:8].chunk.js',
     filename: '[name].[chunkhash:8].js',
-    libraryTarget: 'umd',
-    umdNamedDefine: true,
+    libraryTarget: 'module',
   },
   plugins: [
     new CleanWebpackPlugin(),

--- a/centreon/webpack.config.js
+++ b/centreon/webpack.config.js
@@ -14,6 +14,7 @@ module.exports = (jscTransformConfiguration) =>
       entry: ['./www/front_src/src/index.tsx'],
       output: {
         crossOriginLoading: 'anonymous',
+        library: ['name'],
         path: path.resolve(`${__dirname}/www/static`),
         publicPath: './static/',
       },

--- a/centreon/webpack.config.js
+++ b/centreon/webpack.config.js
@@ -14,7 +14,6 @@ module.exports = (jscTransformConfiguration) =>
       entry: ['./www/front_src/src/index.tsx'],
       output: {
         crossOriginLoading: 'anonymous',
-        library: ['name'],
         path: path.resolve(`${__dirname}/www/static`),
         publicPath: './static/',
       },

--- a/centreon/www/front_src/src/Header/index.tsx
+++ b/centreon/www/front_src/src/Header/index.tsx
@@ -19,7 +19,6 @@ export const isDarkMode = (theme: Theme): boolean =>
 
 export const headerHeight = 7;
 
-// no meaning comment
 const useStyles = makeStyles((theme) => ({
   header: {
     alignItems: 'center',

--- a/centreon/www/front_src/src/Header/index.tsx
+++ b/centreon/www/front_src/src/Header/index.tsx
@@ -19,6 +19,7 @@ export const isDarkMode = (theme: Theme): boolean =>
 
 export const headerHeight = 7;
 
+// no meaning comment
 const useStyles = makeStyles((theme) => ({
   header: {
     alignItems: 'center',


### PR DESCRIPTION
## Description

Change the webpack configuration libraryTarget from umd to module with the aim to reduce the bundle size 

bundle size comparison 

UMD 

https://user-images.githubusercontent.com/109956462/200534650-a660197d-0b6b-4867-bdf3-00bcea07378c.mp4


module 

https://user-images.githubusercontent.com/109956462/200534810-9061d82c-6f08-49b5-af8b-229d566ab207.mp4

lighthouse comparison

umd 

![lighthouse-umd](https://user-images.githubusercontent.com/109956462/200594440-69045908-3235-41a9-833c-f77863ab04cc.PNG)

module

![lighthouse-module](https://user-images.githubusercontent.com/109956462/200594524-fe4a43b6-da1d-4384-bf29-10e8c5a22c34.PNG)


## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.04.x
- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x (master)

<h2> How this pull request can be tested ? </h2>

Validate that user can access to pages (should be validated by cypress and ligthouse)
Execute minimal TNR on legacy / reactJS pages

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
