### PR TITLE
change module type to module instead of umd in webpack configuration

### DIFF
--- a/centreon/package-lock.json
+++ b/centreon/package-lock.json
@@ -25,6 +25,10 @@
         "@visx/threshold": "^2.12.2",
         "@visx/visx": "2.9.0",
         "axios": "^0.25.0",
+<<<<<<< HEAD
+=======
+        "centreon-frontend": "git+https://centreon@github.com/centreon/centreon-frontend.git#MON-15778-poc-change-module-type-to-module-instead-of-umd-in-webpack-configuration",
+>>>>>>> centreon/MON-15778-poc-change-module-type-to-module-instead-of-umd-in-webpack-configuration
         "classnames": "^2.3.1",
         "clsx": "^1.1.1",
         "connected-react-router": "^6.9.2",
@@ -18146,6 +18150,7 @@
       "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==",
       "dev": true
     },
+<<<<<<< HEAD
     "node_modules/ccount": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/ccount/-/ccount-1.1.0.tgz",
@@ -18154,6 +18159,89 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+=======
+    "node_modules/centreon-frontend": {
+      "version": "22.10.0",
+      "resolved": "git+https://centreon@github.com/centreon/centreon-frontend.git#52e08347523a15322249180c58e686bb10b0e7a9",
+      "license": "GPL-2.0",
+      "dependencies": {
+        "@dnd-kit/core": "^5.0.3",
+        "@dnd-kit/modifiers": "^5.0.0",
+        "@dnd-kit/sortable": "^6.0.1",
+        "@dnd-kit/utilities": "^3.1.0",
+        "@emotion/react": "^11.9.0",
+        "@emotion/styled": "^11.8.1",
+        "@mui/icons-material": "^5.6.2",
+        "@mui/lab": "^5.0.0-alpha.80",
+        "@mui/material": "^5.6.4",
+        "@mui/styles": "^5.10.2",
+        "anylogger": "^1.0.11",
+        "axios": "^0.27.2",
+        "clsx": "^1.1.1",
+        "dayjs": "^1.11.2",
+        "formik": "^2.2.9",
+        "humanize-duration": "^3.27.1",
+        "i18next": "^21.7.1",
+        "notistack": "2.0.4",
+        "numeral": "^2.0.6",
+        "prop-types": "^15.8.1",
+        "ramda": "^0.28.0",
+        "react": "^18.1.0",
+        "react-dom": "^18.1.0",
+        "react-i18next": "^11.16.9",
+        "react-router-dom": "^6.3.0",
+        "react-transition-group": "^4.4.2",
+        "resize-observer-polyfill": "^1.5.1",
+        "ts.data.json": "^2.1.0",
+        "ulog": "^2.0.0-beta.19"
+      },
+      "peerDependencies": {
+        "@swc/core": "1.x",
+        "@swc/jest": "0.x",
+        "@tanstack/react-query": "4.x",
+        "@tanstack/react-query-devtools": "4.x",
+        "@testing-library/jest-dom": "5.x",
+        "@testing-library/react": "13.x",
+        "@types/ramda": "0.28.x",
+        "@typescript-eslint/eslint-plugin": "^5.x",
+        "@typescript-eslint/parser": "^5.x",
+        "clean-webpack-plugin": "^4.x",
+        "eslint": "8.x",
+        "eslint-config-airbnb": "19.x",
+        "eslint-config-airbnb-base": "^15.x",
+        "eslint-config-prettier": "8.x",
+        "eslint-import-resolver-alias": "1.x",
+        "eslint-plugin-hooks": "0.x",
+        "eslint-plugin-import": "2.x",
+        "eslint-plugin-jsx-a11y": "6.x",
+        "eslint-plugin-prefer-arrow-functions": "3.x",
+        "eslint-plugin-prettier": "4.x",
+        "eslint-plugin-react": "7.x",
+        "eslint-plugin-react-hooks": "4.x",
+        "eslint-plugin-sort-keys-fix": "1.x",
+        "eslint-plugin-typescript-sort-keys": "2.x",
+        "identity-obj-proxy": "3.x",
+        "jest": "28.x",
+        "jest-fetch-mock": "^3.x",
+        "jotai": "^1.6.5",
+        "jotai-suspense": "^0.1.x",
+        "prettier": "2.x",
+        "resolve-url-loader": "5.x",
+        "swc-loader": "0.x",
+        "tss-react": "4.x",
+        "typescript": "4.x",
+        "url-loader": "4.x.x",
+        "webpack-merge": "5.x"
+      }
+    },
+    "node_modules/centreon-frontend/node_modules/axios": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
+      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
+      "dependencies": {
+        "follow-redirects": "^1.14.9",
+        "form-data": "^4.0.0"
+>>>>>>> centreon/MON-15778-poc-change-module-type-to-module-instead-of-umd-in-webpack-configuration
       }
     },
     "node_modules/chalk": {
@@ -52718,6 +52806,49 @@
         "@visx/shape": "2.12.2",
         "classnames": "^2.3.1",
         "prop-types": "^15.5.10"
+<<<<<<< HEAD
+=======
+      },
+      "dependencies": {
+        "@visx/clip-path": {
+          "version": "2.10.0",
+          "resolved": "https://registry.npmjs.org/@visx/clip-path/-/clip-path-2.10.0.tgz",
+          "integrity": "sha512-YIUQstsHKGysyDISOV5p+fMymkUdHCs89nSY/w6TG9EIl8x2jRhrQdojwtCYvjLkPZiZiKa8MBT6fFzsSfGImg==",
+          "requires": {
+            "@types/react": "*",
+            "prop-types": "^15.5.10"
+          }
+        },
+        "@visx/group": {
+          "version": "2.10.0",
+          "resolved": "https://registry.npmjs.org/@visx/group/-/group-2.10.0.tgz",
+          "integrity": "sha512-DNJDX71f65Et1+UgQvYlZbE66owYUAfcxTkC96Db6TnxV221VKI3T5l23UWbnMzwFBP9dR3PWUjjqhhF12N5pA==",
+          "requires": {
+            "@types/react": "*",
+            "classnames": "^2.3.1",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "@visx/shape": {
+          "version": "2.12.2",
+          "resolved": "https://registry.npmjs.org/@visx/shape/-/shape-2.12.2.tgz",
+          "integrity": "sha512-4gN0fyHWYXiJ+Ck8VAazXX0i8TOnLJvOc5jZBnaJDVxgnSIfCjJn0+Nsy96l9Dy/bCMTh4DBYUBv9k+YICBUOA==",
+          "requires": {
+            "@types/d3-path": "^1.0.8",
+            "@types/d3-shape": "^1.3.1",
+            "@types/lodash": "^4.14.172",
+            "@types/react": "*",
+            "@visx/curve": "2.1.0",
+            "@visx/group": "2.10.0",
+            "@visx/scale": "2.2.2",
+            "classnames": "^2.3.1",
+            "d3-path": "^1.0.5",
+            "d3-shape": "^1.2.0",
+            "lodash": "^4.17.21",
+            "prop-types": "^15.5.10"
+          }
+        }
+>>>>>>> centreon/MON-15778-poc-change-module-type-to-module-instead-of-umd-in-webpack-configuration
       }
     },
     "@visx/tooltip": {
@@ -54979,11 +55110,59 @@
       "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==",
       "dev": true
     },
+<<<<<<< HEAD
     "ccount": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/ccount/-/ccount-1.1.0.tgz",
       "integrity": "sha512-vlNK021QdI7PNeiUh/lKkC/mNHHfV0m/Ad5JoI0TYtlBnJAslM/JIkm/tGC88bkLIwO6OQ5uV6ztS6kVAtCDlg==",
       "dev": true
+=======
+    "centreon-frontend": {
+      "version": "git+https://centreon@github.com/centreon/centreon-frontend.git#52e08347523a15322249180c58e686bb10b0e7a9",
+      "from": "centreon-frontend@git+https://centreon@github.com/centreon/centreon-frontend.git#MON-15778-poc-change-module-type-to-module-instead-of-umd-in-webpack-configuration",
+      "requires": {
+        "@dnd-kit/core": "^5.0.3",
+        "@dnd-kit/modifiers": "^5.0.0",
+        "@dnd-kit/sortable": "^6.0.1",
+        "@dnd-kit/utilities": "^3.1.0",
+        "@emotion/react": "^11.9.0",
+        "@emotion/styled": "^11.8.1",
+        "@mui/icons-material": "^5.6.2",
+        "@mui/lab": "^5.0.0-alpha.80",
+        "@mui/material": "^5.6.4",
+        "@mui/styles": "^5.10.2",
+        "anylogger": "^1.0.11",
+        "axios": "^0.27.2",
+        "clsx": "^1.1.1",
+        "dayjs": "^1.11.2",
+        "formik": "^2.2.9",
+        "humanize-duration": "^3.27.1",
+        "i18next": "^21.7.1",
+        "notistack": "2.0.4",
+        "numeral": "^2.0.6",
+        "prop-types": "^15.8.1",
+        "ramda": "^0.28.0",
+        "react": "^18.1.0",
+        "react-dom": "^18.1.0",
+        "react-i18next": "^11.16.9",
+        "react-router-dom": "^6.3.0",
+        "react-transition-group": "^4.4.2",
+        "resize-observer-polyfill": "^1.5.1",
+        "ts.data.json": "^2.1.0",
+        "ulog": "^2.0.0-beta.19"
+      },
+      "dependencies": {
+        "axios": {
+          "version": "0.27.2",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
+          "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
+          "requires": {
+            "follow-redirects": "^1.14.9",
+            "form-data": "^4.0.0"
+          }
+        }
+      }
+>>>>>>> centreon/MON-15778-poc-change-module-type-to-module-instead-of-umd-in-webpack-configuration
     },
     "chalk": {
       "version": "2.4.2",

--- a/centreon/package.json
+++ b/centreon/package.json
@@ -95,6 +95,10 @@
     "@visx/threshold": "^2.12.2",
     "@visx/visx": "2.9.0",
     "axios": "^0.25.0",
+<<<<<<< HEAD
+=======
+    "centreon-frontend": "git+https://centreon@github.com/centreon/centreon-frontend.git#MON-15778-poc-change-module-type-to-module-instead-of-umd-in-webpack-configuration",
+>>>>>>> centreon/MON-15778-poc-change-module-type-to-module-instead-of-umd-in-webpack-configuration
     "classnames": "^2.3.1",
     "clsx": "^1.1.1",
     "connected-react-router": "^6.9.2",

--- a/centreon/webpack.config.js
+++ b/centreon/webpack.config.js
@@ -14,7 +14,6 @@ module.exports = (jscTransformConfiguration) =>
       entry: ['./www/front_src/src/index.tsx'],
       output: {
         crossOriginLoading: 'anonymous',
-        library: ['name'],
         path: path.resolve(`${__dirname}/www/static`),
         publicPath: './static/',
       },


### PR DESCRIPTION
## Description

Change the webpack configuration libraryTarget from umd to module with the aim to reduce the bundle size


## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.04.x
- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x (master)

<h2> How this pull request can be tested ? </h2>

Validate that user can access to pages (should be validated by cypress and ligthouse)
Execute minimal TNR on legacy / reactJS pages

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).