### PR TITLE
feat[widgets]: Add the possibility to filter by services acknowledged by me [service-monitoring] (develop)

### DIFF
--- a/widgets/centreon-widget-service-monitoring/service-monitoring/configs.xml
+++ b/widgets/centreon-widget-service-monitoring/service-monitoring/configs.xml
@@ -24,6 +24,7 @@
     <preference label="Acknowledgement Filter" name="acknowledgement_filter" defaultValue="all" type="list">
       <option value="ack" label="Acknowledged"/>
       <option value="nack" label="Not Acknowleged"/>
+      <option value="ackByMe" label="Acknowleged By Me"/>
     </preference>
     <preference label="Notification Filter" name="notification_filter" defaultValue="all" type="list">
       <option value="enabled" label="Notification Enabled"/>

--- a/widgets/centreon-widget-service-monitoring/service-monitoring/src/index.php
+++ b/widgets/centreon-widget-service-monitoring/service-monitoring/src/index.php
@@ -158,7 +158,13 @@ $query = 'SELECT SQL_CALC_FOUND_ROWS h.host_id,
         s.service_id = cv2.service_id
         AND s.host_id = cv2.host_id
         AND cv2.name = \'CRITICALITY_ID\'
-    ) ';
+    )';
+
+if (isset($preferences['acknowledgement_filter']) &&  $preferences['acknowledgement_filter'] == 'ackByMe') {
+    $query .= ' JOIN acknowledgements ack ON (
+        s.service_id = ack.service_id
+    )';
+}
 
 if (!$centreon->user->admin) {
     $query .= ' , centreon_acl acl ';
@@ -231,10 +237,12 @@ if (isset($preferences['hide_unreachable_host']) && $preferences['hide_unreachab
 if (count($stateTab)) {
     $query = CentreonUtils::conditionBuilder($query, ' s.state IN (' . implode(',', $stateTab) . ')');
 }
-
 if (isset($preferences['acknowledgement_filter']) && $preferences['acknowledgement_filter']) {
     if ($preferences['acknowledgement_filter'] == 'ack') {
         $query = CentreonUtils::conditionBuilder($query, ' s.acknowledged = 1');
+    } elseif ($preferences['acknowledgement_filter'] == 'ackByMe') {
+        $query = CentreonUtils::conditionBuilder($query, ' s.acknowledged = 1 AND ack.author = "'
+            . $centreon->user->alias . '"');
     } elseif ($preferences['acknowledgement_filter'] == 'nack') {
         $query = CentreonUtils::conditionBuilder(
             $query,


### PR DESCRIPTION
## Description

Given a user adding the service-monitoring widget
He can edit configuration select “Acknowledged by me” filter option
And see only services Acknowledged by itself

**Fixes** # MON-14592

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.04.x
- [ ] 21.10.x
- [ ] 22.04.x
- [x] 22.10.x (master)

<h2> How this pull request can be tested ? </h2>

1. Acknowledge services
2. Add the service-monitoring widget
3. Edit widget configuration and choose “Acknowledged by me” filter
4. Check that only services acknowledged by yourself are displayed on listing

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).