### PR TITLE
enh(ui): Set id and data-testid on each contact form inputs

### DIFF
--- a/centreon/www/include/configuration/configObject/contact/formContact.php
+++ b/centreon/www/include/configuration/configObject/contact/formContact.php
@@ -205,7 +205,7 @@ $DBRESULT->closeCursor();
 /**
  * Template / Style for Quickform input
  */
-$attrsText = array("size" => "30");
+$attrsText = ["size" => "30"];
 $attrsText2 = array("size" => "60");
 $attrsTextDescr = array("size" => "80");
 $attrsTextMail = array("size" => "90");
@@ -317,16 +317,51 @@ $form->addElement('header', 'acl', _("Access lists"));
  * Don't change contact name, alias or autologin key in massive change
  */
 if ($o != MASSIVE_CHANGE) {
+    /**
+     * Contact name attributes
+     */
+    $attrsTextDescr["id"] = "contact_name";
+    $attrsTextDescr["data-testid"] = "contact_name";
     $form->addElement('text', 'contact_name', _("Full Name"), $attrsTextDescr);
+
+    /**
+     * Contact alias attributes
+     */
+    $attrsText["id"] = "contact_alias";
+    $attrsText["data-testid"] = "contact_alias";
     $form->addElement('text', 'contact_alias', _("Alias / Login"), $attrsText);
-    $form->addElement('text', 'contact_autologin_key', _("Autologin Key"), array("size" => "90", "id" => "aKey"));
+
+    $form->addElement(
+        'text',
+        'contact_autologin_key',
+        _("Autologin Key"),
+        [
+            "size" => "90",
+            "id" => "aKey",
+            "data-testid" => "aKey"
+        ]
+    );
     $form->addElement(
         'button',
         'contact_gen_akey',
         _("Generate"),
-        ['onclick' => "generatePassword('aKey', '$encodedPasswordPolicy');"]
+        [
+            'onclick' => "generatePassword('aKey', '$encodedPasswordPolicy');",
+            "id" => "contact_gen_akey",
+            "data-testid" => "contact_gen_akey"
+        ]
     );
+    /**
+     * Contact email attributes
+     */
+    $attrsTextMail["id"] = "contact_email";
+    $attrsTextMail["data-testid"] = "contact_email";
     $form->addElement('text', 'contact_email', _("Email"), $attrsTextMail);
+    /**
+     * Contact Pager attributes
+     */
+    $attrsText["id"] = "contact_pager";
+    $attrsText["data-testid"] = "contact_pager";
     $form->addElement('text', 'contact_pager', _("Pager"), $attrsText);
 }
 
@@ -334,15 +369,22 @@ if ($o != MASSIVE_CHANGE) {
 /**
  * Contact template used
  */
-$form->addElement('select', 'contact_template_id', _("Contact template used"), $contactTpl);
-
+$form->addElement(
+    'select', 
+    'contact_template_id', 
+    _("Contact template used"), 
+    $contactTpl, 
+    [
+        "id" => "contact_template_id", 
+        "data-testid" => "contact_template_id"
+    ]
+);
 $form->addElement('header', 'furtherAddress', _("Additional Addresses"));
-$form->addElement('text', 'contact_address1', _("Address1"), $attrsText);
-$form->addElement('text', 'contact_address2', _("Address2"), $attrsText);
-$form->addElement('text', 'contact_address3', _("Address3"), $attrsText);
-$form->addElement('text', 'contact_address4', _("Address4"), $attrsText);
-$form->addElement('text', 'contact_address5', _("Address5"), $attrsText);
-$form->addElement('text', 'contact_address6', _("Address6"), $attrsText);
+for ($i=0; $i < 6; $i++) { 
+    $attrsText["id"] = "contact_address" . $i + 1;
+    $attrsText["data-testid"] = "contact_address" . $i + 1;
+    $form->addElement('text', 'contact_address' . $i+1, _("Address" . $i + 1), $attrsText);
+}
 
 /**
  * Contact Groups Field
@@ -363,15 +405,41 @@ $attrContactgroup1 = array_merge(
     $attrContactgroups,
     array('defaultDatasetRoute' => $defaultDatasetRoute)
 );
-$form->addElement('select2', 'contact_cgNotif', _("Linked to Contact Groups"), [], $attrContactgroup1);
+$form->addElement(
+    'select2',
+    'contact_cgNotif',
+    _("Linked to Contact Groups"),
+    [],
+    $attrContactgroup1
+);
 
 /**
  * Contact Centreon information
  */
 $form->addElement('header', 'oreon', _("Centreon"));
 $tab = [];
-$tab[] = $form->createElement('radio', 'contact_oreon', null, _("Yes"), '1');
-$tab[] = $form->createElement('radio', 'contact_oreon', null, _("No"), '0');
+$tab[] = $form->createElement(
+    'radio',
+    'contact_oreon',
+    null,
+    _("Yes"),
+    '1',
+    [
+        "id" => "contact_oreon_yes",
+        "data-testid" => "contact_oreon_yes"
+    ]
+);
+$tab[] = $form->createElement(
+    'radio',
+    'contact_oreon',
+    null,
+    _("No"),
+    '0',
+    [
+        "id" => "contact_oreon_no",
+        "data-testid" => "contact_oreon_no"
+    ]
+);
 $form->addGroup($tab, 'contact_oreon', _("Reach Centreon Front-end"), '&nbsp;');
 
 if ($o !== MASSIVE_CHANGE) {
@@ -379,33 +447,48 @@ if ($o !== MASSIVE_CHANGE) {
         'password',
         'contact_passwd',
         _("Password"),
-        array(
+        [
             "size" => "30",
             "autocomplete" => "new-password",
             "id" => "passwd1",
+            "data-testid" => "passwd1",
             "onkeypress" => "resetPwdType(this);"
-        )
+        ]
     );
     $form->addElement(
         'password',
         'contact_passwd2',
         _("Confirm Password"),
-        array(
+        [
             "size" => "30",
             "autocomplete" => "new-password",
             "id" => "passwd2",
+            "data-testid" => "passwd2",
             "onkeypress" => "resetPwdType(this);"
-        )
+        ]
     );
     $form->addElement(
         'button',
         'contact_gen_passwd',
         _("Generate"),
-        ['onclick' => "generatePassword('passwd', '$encodedPasswordPolicy');"]
+        [
+            'onclick' => "generatePassword('passwd', '$encodedPasswordPolicy');",
+            "id" => "contact_gen_passwd",
+            "data-testid" => "contact_gen_passwd"
+        ]
     );
 }
 
-$form->addElement('select', 'contact_lang', _("Default Language"), $langs);
+$form->addElement(
+    'select',
+    'contact_lang',
+    _("Default Language"),
+    $langs,
+    [
+        "id" => "contact_lang",
+        "data-testid" => "contact_lang"
+    ]
+);
 $form->addElement(
     'select',
     'contact_type_msg',
@@ -415,18 +498,60 @@ $form->addElement(
 
 if ($centreon->user->admin) {
     $tab = array();
-    $tab[] = $form->createElement('radio', 'contact_admin', null, _("Yes"), '1');
-    $tab[] = $form->createElement('radio', 'contact_admin', null, _("No"), '0');
+    $tab[] = $form->createElement(
+        'radio',
+        'contact_admin',
+        null,
+        _("Yes"),
+        '1',
+        ["id" => "contact_admin_yes", "data-testid" => "contact_admin_yes"]
+    );
+    $tab[] = $form->createElement(
+        'radio',
+        'contact_admin',
+        null,
+        _("No"),
+        '0',
+        ["id" => "contact_admin_no", "data-testid" => "contact_admin_no"]
+    );
     $form->addGroup($tab, 'contact_admin', _("Admin"), '&nbsp;');
 
     $tab = array();
-    $tab[] = $form->createElement('radio', 'reach_api', null, _("Yes"), '1');
-    $tab[] = $form->createElement('radio', 'reach_api', null, _("No"), '0');
+    $tab[] = $form->createElement(
+            'radio',
+            'reach_api',
+            null,
+            _("Yes"),
+            '1',
+            ["id" => "reach_api_yes", "data-testid" => "reach_api_yes"]
+        );
+    $tab[] = $form->createElement(
+        'radio',
+        'reach_api',
+        null,
+        _("No"),
+        '0',
+        ["id" => "reach_api_no", "data-testid" => "reach_api_no"]
+    );
     $form->addGroup($tab, 'reach_api', _("Reach API Configuration"), '&nbsp;');
 
     $tab = array();
-    $tab[] = $form->createElement('radio', 'reach_api_rt', null, _("Yes"), '1');
-    $tab[] = $form->createElement('radio', 'reach_api_rt', null, _("No"), '0');
+    $tab[] = $form->createElement(
+            'radio',
+            'reach_api_rt',
+            null,
+            _("Yes"),
+            '1',
+            ["id" => "reach_api_rt_yes", "data-testid" => "reach_api_rt_yes"]
+        );
+    $tab[] = $form->createElement(
+        'radio',
+        'reach_api_rt',
+        null,
+        _("No"),
+        '0',
+        ["id" => "reach_api_rt_no", "data-testid" => "reach_api_rt_no"]
+    );
     $form->addGroup($tab, 'reach_api_rt', _("Reach API Realtime"), '&nbsp;');
 }
 
@@ -447,7 +572,13 @@ $attrAclgroup1 = array_merge(
     $attrAclgroups,
     array('defaultDatasetRoute' => $defaultDatasetRoute)
 );
-$form->addElement('select2', 'contact_acl_groups', _("Access list groups"), array(), $attrAclgroup1);
+$form->addElement(
+    'select2',
+    'contact_acl_groups',
+    _("Access list groups"),
+    [],
+    $attrAclgroup1,
+);
 
 /**
  * Include GMT Class
@@ -467,7 +598,13 @@ $attrTimezones = array(
     'multiple' => false,
     'linkedObject' => 'centreonGMT'
 );
-$form->addElement('select2', 'contact_location', _("Timezone / Location"), array(), $attrTimezones);
+$form->addElement(
+    'select2',
+    'contact_location',
+    _("Timezone / Location"),
+    [],
+    $attrTimezones
+);
 
 if ($o != MASSIVE_CHANGE) {
     $auth_type = array();
@@ -478,6 +615,11 @@ if ($o != MASSIVE_CHANGE) {
 $auth_type["local"] = "Centreon";
 if ($centreon->optGen['ldap_auth_enable'] == 1) {
     $auth_type["ldap"] = "LDAP";
+    /**
+     * LDAP Distinguished Name attributes
+     */
+    $attrsText2["id"] = "contact_ldap_dn";
+    $attrsText2["data-testid"] = "contact_ldap_dn";
     $dnElement = $form->addElement('text', 'contact_ldap_dn', _("LDAP DN (Distinguished Name)"), $attrsText2);
     if (!$centreon->user->admin) {
         $dnElement->freeze();
@@ -491,7 +633,16 @@ if ($o != MASSIVE_CHANGE) {
         'reach_api_rt' => ['reach_api_rt' => '0']
     ]);
 }
-$form->addElement('select', 'contact_auth_type', _("Authentication Source"), $auth_type);
+$form->addElement(
+    'select',
+    'contact_auth_type',
+    _("Authentication Source"),
+    $auth_type,
+    [
+        "id" => "contact_auth_type",
+        "data-testid" => "contact_auth_type"
+    ]
+);
 
 /**
  * Notification informations
@@ -499,9 +650,33 @@ $form->addElement('select', 'contact_auth_type', _("Authentication Source"), $au
 $form->addElement('header', 'notification', _("Notification"));
 
 $tab = [];
-$tab[] = $form->createElement('radio', 'contact_enable_notifications', null, _("Yes"), '1');
-$tab[] = $form->createElement('radio', 'contact_enable_notifications', null, _("No"), '0');
-$tab[] = $form->createElement('radio', 'contact_enable_notifications', null, _("Default"), '2');
+$tab[] = $form->createElement(
+    'radio',
+    'contact_enable_notifications',
+    null,
+    _("Yes"),
+    '1',
+    ["data-testid" => "contact_enable_notifications_yes"]
+);
+$tab[] = $form->createElement(
+    'radio',
+    'contact_enable_notifications',
+    null,
+    _("No"),
+    '0',
+    ["data-testid" => "contact_enable_notifications_no"]
+);
+$tab[] = $form->createElement(
+    'radio',
+    'contact_enable_notifications',
+    null,
+    _("Default"),
+    '2',
+    [
+        "id" => "contact_enable_notifications_default",
+        "data-testid" => "contact_enable_notifications_default"
+    ]
+);
 $form->addGroup($tab, 'contact_enable_notifications', _("Enable Notifications"), '&nbsp;');
 if ($o != MASSIVE_CHANGE) {
     $form->setDefaults(array('contact_enable_notifications' => '2'));
@@ -516,42 +691,42 @@ $hostNotifOpt[] = $form->createElement(
     'd',
     '&nbsp;',
     _("Down"),
-    array('id' => 'hDown', 'onClick' => 'uncheckAllH(this);')
+    array('id' => 'hDown', 'onClick' => 'uncheckAllH(this);', "data-testid" => "hDown")
 );
 $hostNotifOpt[] = $form->createElement(
     'checkbox',
     'u',
     '&nbsp;',
     _("Unreachable"),
-    array('id' => 'hUnreachable', 'onClick' => 'uncheckAllH(this);')
+    array('id' => 'hUnreachable', 'onClick' => 'uncheckAllH(this);', "data-testid" => "hUnreachable")
 );
 $hostNotifOpt[] = $form->createElement(
     'checkbox',
     'r',
     '&nbsp;',
     _("Recovery"),
-    array('id' => 'hRecovery', 'onClick' => 'uncheckAllH(this);')
+    array('id' => 'hRecovery', 'onClick' => 'uncheckAllH(this);', "data-testid" => "hRecovery")
 );
 $hostNotifOpt[] = $form->createElement(
     'checkbox',
     'f',
     '&nbsp;',
     _("Flapping"),
-    array('id' => 'hFlapping', 'onClick' => 'uncheckAllH(this);')
+    array('id' => 'hFlapping', 'onClick' => 'uncheckAllH(this);', "data-testid" => "hFlapping")
 );
 $hostNotifOpt[] = $form->createElement(
     'checkbox',
     's',
     '&nbsp;',
     _("Downtime Scheduled"),
-    array('id' => 'hScheduled', 'onClick' => 'uncheckAllH(this);')
+    array('id' => 'hScheduled', 'onClick' => 'uncheckAllH(this);', "data-testid" => "hScheduled")
 );
 $hostNotifOpt[] = $form->createElement(
     'checkbox',
     'n',
     '&nbsp;',
     _("None"),
-    array('id' => 'hNone', 'onClick' => 'javascript:uncheckAllH(this);')
+    array('id' => 'hNone', 'onClick' => 'javascript:uncheckAllH(this);', "data-testid" => "hNone")
 );
 $form->addGroup($hostNotifOpt, 'contact_hostNotifOpts', _("Host Notification Options"), '&nbsp;&nbsp;');
 
@@ -561,7 +736,13 @@ $attrTimeperiod1 = array_merge(
     $attrTimeperiods,
     array('defaultDatasetRoute' => $defaultDatasetRoute)
 );
-$form->addElement('select2', 'timeperiod_tp_id', _("Host Notification Period"), array(), $attrTimeperiod1);
+$form->addElement(
+    'select2',
+    'timeperiod_tp_id',
+    _("Host Notification Period"),
+    [],
+    $attrTimeperiod1
+);
 
 
 unset($hostNotifOpt);
@@ -585,7 +766,13 @@ $attrCommand1 = array_merge(
         'availableDatasetRoute' => $availableDatasetRoute
     )
 );
-$form->addElement('select2', 'contact_hostNotifCmds', _("Host Notification Commands"), array(), $attrCommand1);
+$form->addElement(
+    'select2',
+    'contact_hostNotifCmds',
+    _("Host Notification Commands"),
+    [],
+    $attrCommand1
+);
 
 /** * *****************************
  * Service notifications
@@ -596,49 +783,49 @@ $svNotifOpt[] = $form->createElement(
     'w',
     '&nbsp;',
     _("Warning"),
-    array('id' => 'sWarning', 'onClick' => 'uncheckAllS(this);')
+    array('id' => 'sWarning', 'onClick' => 'uncheckAllS(this);', "data-testid" => "sWarning")
 );
 $svNotifOpt[] = $form->createElement(
     'checkbox',
     'u',
     '&nbsp;',
     _("Unknown"),
-    array('id' => 'sUnknown', 'onClick' => 'uncheckAllS(this);')
+    array('id' => 'sUnknown', 'onClick' => 'uncheckAllS(this);', "data-testid" => "sUnknown")
 );
 $svNotifOpt[] = $form->createElement(
     'checkbox',
     'c',
     '&nbsp;',
     _("Critical"),
-    array('id' => 'sCritical', 'onClick' => 'uncheckAllS(this);')
+    array('id' => 'sCritical', 'onClick' => 'uncheckAllS(this);', "data-testid" => "sCritical")
 );
 $svNotifOpt[] = $form->createElement(
     'checkbox',
     'r',
     '&nbsp;',
     _("Recovery"),
-    array('id' => 'sRecovery', 'onClick' => 'uncheckAllS(this);')
+    array('id' => 'sRecovery', 'onClick' => 'uncheckAllS(this);', "data-testid" => "sRecovery")
 );
 $svNotifOpt[] = $form->createElement(
     'checkbox',
     'f',
     '&nbsp;',
     _("Flapping"),
-    array('id' => 'sFlapping', 'onClick' => 'uncheckAllS(this);')
+    array('id' => 'sFlapping', 'onClick' => 'uncheckAllS(this);', "data-testid" => "sFlapping")
 );
 $svNotifOpt[] = $form->createElement(
     'checkbox',
     's',
     '&nbsp;',
     _("Downtime Scheduled"),
-    array('id' => 'sScheduled', 'onClick' => 'uncheckAllS(this);')
+    array('id' => 'sScheduled', 'onClick' => 'uncheckAllS(this);', "data-testid" => "sScheduled")
 );
 $svNotifOpt[] = $form->createElement(
     'checkbox',
     'n',
     '&nbsp;',
     _("None"),
-    array('id' => 'sNone', 'onClick' => 'uncheckAllS(this);')
+    array('id' => 'sNone', 'onClick' => 'uncheckAllS(this);', "data-testid" => "sNone")
 );
 $form->addGroup($svNotifOpt, 'contact_svNotifOpts', _("Service Notification Options"), '&nbsp;&nbsp;');
 
@@ -650,7 +837,13 @@ $attrTimeperiod2 = array_merge(
     $attrTimeperiods,
     array('defaultDatasetRoute' => $defaultAttrTimeperiod2Route)
 );
-$form->addElement('select2', 'timeperiod_tp_id2', _("Service Notification Period"), array(), $attrTimeperiod2);
+$form->addElement(
+    'select2',
+    'timeperiod_tp_id2',
+    _("Service Notification Period"),
+    [],
+    $attrTimeperiod2
+);
 
 if ($o == MASSIVE_CHANGE) {
     $mc_mod_svcmds = array();
@@ -672,14 +865,34 @@ $attrCommand2 = array_merge(
         'availableDatasetRoute' => $availableCommand2Route
     )
 );
-$form->addElement('select2', 'contact_svNotifCmds', _("Service Notification Commands"), array(), $attrCommand2);
+$form->addElement(
+    'select2',
+    'contact_svNotifCmds',
+    _("Service Notification Commands"),
+    [],
+    $attrCommand2
+);
 
 /**
  * Further informations
  */
 $form->addElement('header', 'furtherInfos', _("Additional Information"));
-$cctActivation[] = $form->createElement('radio', 'contact_activate', null, _("Enabled"), '1');
-$cctActivation[] = $form->createElement('radio', 'contact_activate', null, _("Disabled"), '0');
+$cctActivation[] = $form->createElement(
+    'radio',
+    'contact_activate',
+    null,
+    _("Enabled"),
+    '1',
+    ["id" => "contact_activate_enable", "data-testid" => "contact_activate_enable"]
+);
+$cctActivation[] = $form->createElement(
+    'radio',
+    'contact_activate',
+    null,
+    _("Disabled"),
+    '0',
+    ["id" => "contact_activate_disable", "data-testid" => "contact_activate_disable"]
+);
 $form->addGroup($cctActivation, 'contact_activate', _("Status"), '&nbsp;');
 $form->setDefaults(array('contact_activate' => '1'));
 if ($o == MODIFY_CONTACT && $centreon->user->get_id() == $cct["contact_id"]) {
@@ -688,7 +901,11 @@ if ($o == MODIFY_CONTACT && $centreon->user->get_id() == $cct["contact_id"]) {
 
 $form->addElement('hidden', 'contact_register');
 $form->setDefaults(array('contact_register' => '1'));
-
+/**
+ * Comments attributes
+ */
+$attrsTextarea["id"] = "contact_comment";
+$attrsTextarea["data-testid"] = "contact_comment";
 $form->addElement('textarea', 'contact_comment', _("Comments"), $attrsTextarea);
 
 $form->addElement('hidden', 'contact_id');

--- a/centreon/www/lib/HTML/QuickForm/select2.php
+++ b/centreon/www/lib/HTML/QuickForm/select2.php
@@ -290,6 +290,7 @@ class HTML_QuickForm_select2 extends HTML_QuickForm_select
         $readonly = '';
         $strHtml .= '<select id="' . $this->getName()
             . '" name="' . $this->getElementHtmlName()
+            . '" data-testid="' . $this->getName()
             . '" ' . $this->_multipleHtml . ' '
             . ' style="width: 300px;" ' . $readonly . '><option></option>'
             . '%%DEFAULT_SELECTED_VALUES%%'


### PR DESCRIPTION
## Description

For test purposes in the future we need data-testid on inputs, this should take care of contact form.

**Fixes** # MON-15825

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [x] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [x] 23.04.x (master)

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
