### PR TITLE
fix(conf) block contacts edition when user's ContactACLs are readonly (develop)

### DIFF
--- a/centreon/www/include/configuration/configObject/contact/contact.php
+++ b/centreon/www/include/configuration/configObject/contact/contact.php
@@ -81,8 +81,6 @@ isset($_GET["dupNbr"]) ? $cG = $_GET["dupNbr"] : $cG = null;
 isset($_POST["dupNbr"]) ? $cP = $_POST["dupNbr"] : $cP = null;
 $cG ? $dupNbr = $cG : $dupNbr = $cP;
 
-$o = \HtmlAnalyzer::sanitizeAndRemoveTags($_POST["o"] ?? $_GET["o"] ?? null);
-
 /*
  * Path to the configuration dir
  */


### PR DESCRIPTION
## Description

When a user ACL's are readonly on users' pages, can still modify them

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.04.x
- [x] 21.10.x
- [x] 22.04.x
- [x] 22.10.x
- [x] 23.04.x  (master)

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).